### PR TITLE
When using upload_scan in response result 'id' is not present in self.data

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -1336,7 +1336,10 @@ class DefectDojoResponse(object):
         self.logger.debug("response_code" + str(self.response_code))
         if self.response_code == 400: #Bad Request
             raise ValueError('Object not created:' + json.dumps(self.data, sort_keys=True, indent=4, separators=(',', ': ')))
-        return int(self.data["id"])
+        if "id" in self.data.keys():
+            return int(self.data["id"])
+        else:
+            return int(self.data["engagement"])        
 
     def count(self):
         return self.data["count"]


### PR DESCRIPTION
When creating a new Engagement and uploading Scan results 'id' is not present in self.data.

Changed to check if 'id' exists, else it will return Engagement ID.

Error:

Traceback (most recent call last):
  File "d.py", line 280, in <module>
    create_findings(dd, engagement_id, args.scanner, args.scan_file_name)
  File "d.py", line 248, in create_findings
    test_id = upload_scan.id()
  File "python/dojotools/v-dd/lib/python3.9/site-packages/defectdojo_api/defectdojo_apiv2.py", line 1339, in id
    return int(self.data["id"])
KeyError: 'id'