### PR TITLE
defectdojo_apiv2: fixes to finding filters

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -607,10 +607,10 @@ class DefectDojoAPIv2(object):
             params['severity__gt'] = severity_gt
 
         if severity_contains:
-            params['severity__contains'] = severity_contains
+            params['severity'] = severity_contains
 
         if title_contains:
-            params['title__contains'] = title_contains
+            params['title'] = title_contains
 
         if url_contains:
             params['url__contains'] = url_contains


### PR DESCRIPTION
For issue #56 

list_findings method accepts filters in fields severity_contains
and title_contains and adds them to query as severity__contains
and title__contains.

However, the related ApiFindingFilter entries do not have
__contains postfixes:

https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/filters.py#L1026