### PR TITLE
Add tags parameter to create_finding

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -731,7 +731,7 @@ class DefectDojoAPIv2(object):
         test_id, user_id, impact, active, verified, mitigation, references=None, build=None, line=0,
         file_path=None, static_finding="False", dynamic_finding="False", false_p="False",
         duplicate="False",  out_of_scope="False", under_review="False", under_defect_review="False",
-        numerical_severity=None, found_by=None):
+        numerical_severity=None, found_by=None, tags=None):
 
         """Creates a finding with the given properties.
 
@@ -778,7 +778,8 @@ class DefectDojoAPIv2(object):
             'under_review' : under_review,
             'under_defect_review' : under_defect_review,
             'numerical_severity' : numerical_severity,
-            'found_by' : [] if found_by is None else found_by
+            'found_by' : [] if found_by is None else found_by,
+            'tags': [] if tags is None else tags
         }
 
         return self._request('POST', 'findings/', data=data)


### PR DESCRIPTION
Adds tags parameter to create_finding.

I can also add this to others like create_engagement.

I see the official docs https://demo.defectdojo.org/api/v2/doc/ say that tags must have min length of 1, I haven't had issues with an empty list of tags. 