### PR TITLE
Allow environment to be specified on scan upload

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -886,7 +886,8 @@ class DefectDojoAPIv2(object):
         )
 
     ##### Upload API #####
-    def upload_scan(self, engagement_id, scan_type, file, active, verified, close_old_findings, skip_duplicates, scan_date, tags=None, build=None, version=None, branch_tag=None, commit_hash=None, minimum_severity="Info", auto_group_by=None):
+    def upload_scan(self, engagement_id, scan_type, file, active, verified, close_old_findings, skip_duplicates, scan_date, tags=None, build=None,
+        version=None, branch_tag=None, commit_hash=None, minimum_severity="Info", auto_group_by=None, environment=None):
         """Uploads and processes a scan file.
 
         :param application_id: Application identifier.
@@ -917,6 +918,7 @@ class DefectDojoAPIv2(object):
             'branch_tag': ('', branch_tag),
             'commit_hash': ('', commit_hash),
             'minimum_severity': ('', minimum_severity),
+            'environment': ('', environment),
             # 'push_to_jira': ('', True)
         }
 
@@ -936,7 +938,8 @@ class DefectDojoAPIv2(object):
         )
 
     ##### Re-upload API #####
-    def reupload_scan(self, test_id, scan_type, file, active, scan_date, tags=None, build=None, version=None, branch_tag=None, commit_hash=None, minimum_severity="Info", auto_group_by=None):
+    def reupload_scan(self, test_id, scan_type, file, active, scan_date, tags=None, build=None, version=None, branch_tag=None, commit_hash=None,
+        minimum_severity="Info", auto_group_by=None, environment=None):
         """Re-uploads and processes a scan file.
 
         :param test_id: Test identifier.
@@ -958,6 +961,7 @@ class DefectDojoAPIv2(object):
             'branch_tag': ('', branch_tag),
             'commit_hash': ('', commit_hash),
 	        'minimum_severity': ('', minimum_severity),
+            'environment': ('', environment),
             # 'push_to_jira': ('', True)
         }
 


### PR DESCRIPTION
Recently, I renamed the environments in my defect dojo instance and found that this caused scan uploads to fail:

```
[08/Jun/2022 12:04:57] ERROR [django.request:224] Internal Server Error: /api/v2/import-scan/
[pid: 44|app: -|req: -/-] 172.18.0.1 (-) {44 vars in 733 bytes} [Wed Jun  8 12:04:57 2022] POST /api/v2/import-scan/ => generated 59 bytes in 35 msecs (HTTP/1.1 500) 7 headers in 212 bytes (1 switches on core 1)
[08/Jun/2022 12:04:58] ERROR [dojo.api_v2.exception_handler:32] Development_Environment matching query does not exist.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/app/./dojo/api_v2/views.py", line 2003, in perform_create
    serializer.save(push_to_jira=push_to_jira)
  File "/app/./dojo/api_v2/serializers.py", line 1436, in save
    environment = Development_Environment.objects.get(name=environment_name)
  File "/usr/local/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/db/models/query.py", line 435, in get
    raise self.model.DoesNotExist(
dojo.models.Development_Environment.DoesNotExist: Development_Environment matching query does not exist.
[08/Jun/2022 12:04:58] ERROR [django.request:224] Internal Server Error: /api/v2/import-scan/
[pid: 44|app: -|req: -/-] 172.18.0.1 (-) {44 vars in 733 bytes} [Wed Jun  8 12:04:58 2022] POST /api/v2/import-scan/ => generated 59 bytes in 35 msecs (HTTP/1.1 500) 7 headers in 212 bytes (1 switches on core 0)
```

I assume this is because when the environment parameter is not sent it defaults to Development (which I had deleted)... To fix this, I have updated the import-scan and reimport-scan endpoint functions to allow for the environment parameter to be specified.