### PR TITLE
Use provided filename for import-scan request

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -971,7 +971,7 @@ class DefectDojoAPIv2(object):
         self.logger.debug(filedata)
 
         data = {
-            'file': filedata,
+            'file': (file, filedata),
             'engagement': ('', engagement_id),
             'scan_type': ('', scan_type),
             'active': ('', active),


### PR DESCRIPTION
Scan uploads without file extensions now fail for certain upload types. This changes the current behavior from using 'file' as the filename for all scan uploads, to using the provided filename. 

Closes #79 